### PR TITLE
スタックフレームの情報取得

### DIFF
--- a/pwndbg/commands/context.py
+++ b/pwndbg/commands/context.py
@@ -569,6 +569,9 @@ def context_memview(target=sys.stdout, with_banner=True, width=None):
     result.append("---------------------------regs---------------------------------")
     for k,v in meminfo.regs.items():
         result.append(k+" : "+hex(v))
+    result.append("---------------------------frames-------------------------------")
+    for k,v in meminfo.frames.items():
+        result.append(k+" : "+hex(v))
     return result
 
 
@@ -604,6 +607,7 @@ def context_backtrace(with_banner=True, target=sys.stdout, width=None):
     frame = newest_frame
     i     = 0
     bt_prefix = "%s" % B.config_prefix
+
     while True:
 
         prefix = bt_prefix if frame == this_frame else ' ' * len(bt_prefix)


### PR DESCRIPTION
`__libc_start_main` のスタックフレームの先頭アドレスだけ取得できない…
それ以外は取得して、`context memview` に表示されるようにした。